### PR TITLE
Fix GNU import library generation

### DIFF
--- a/src/gnu.rs
+++ b/src/gnu.rs
@@ -409,7 +409,7 @@ impl<'a> ObjectFactory<'a> {
             obj.append_section_data(text_sec, jmp_stub, 4);
             obj.add_relocation(
                 text_sec,
-                self.make_relocation(offset, exp_imp_sym, 0, rel_kind),
+                self.make_relocation(offset, exp_imp_sym, -4, rel_kind),
             )
             .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
         }


### PR DESCRIPTION
After commit gimli-rs/object@6dea0d591a38acc11d833f1aff2da711e55edc59, the relocation addend is now adjusted based on the relocation flags. Update our handling to properly account for this change.

Regressed since commit e8e93eecedf16cba6c8bf4872446b1d5114c7d4a.

Resolves: https://github.com/lu-zero/cargo-c/issues/443.