### PR TITLE
fix(gnu): correct i386 thunk relocation and minor section flag bugs

### DIFF
--- a/src/gnu.rs
+++ b/src/gnu.rs
@@ -529,6 +529,107 @@ mod test {
             .unwrap_err();
     }
 
+    /// Regression test for the i386 jump-stub relocation. The `ff 25 disp32`
+    /// instruction is an absolute indirect jump on i386, so the disp32 must
+    /// be patched with the absolute VA of the IAT entry. This requires
+    /// `IMAGE_REL_I386_DIR32` (not `_REL32`), an addend of 0 (encoded as a
+    /// zero in the section data, since COFF has no explicit addend field),
+    /// and the relocation must point at the `__imp__<name>` symbol.
+    #[test]
+    fn test_i386_jump_stub_relocation() {
+        let mut factory = ObjectFactory::new("foo.dll", MachineType::I386).unwrap();
+        let export = ShortExport {
+            name: "_bar".to_string(), // i386 names are mangled with a leading underscore
+            ext_name: None,
+            symbol_name: String::new(),
+            alias_target: String::new(),
+            ordinal: 0,
+            no_name: false,
+            data: false,
+            private: false,
+            constant: false,
+        };
+        let member = factory.make_one(&export).unwrap();
+        let coff = &member.data[..];
+
+        // --- Parse COFF file header (20 bytes) ---
+        let machine = u16::from_le_bytes(coff[0..2].try_into().unwrap());
+        let nsections = u16::from_le_bytes(coff[2..4].try_into().unwrap()) as usize;
+        let sym_table_ptr = u32::from_le_bytes(coff[8..12].try_into().unwrap()) as usize;
+        let nsymbols = u32::from_le_bytes(coff[12..16].try_into().unwrap()) as usize;
+        assert_eq!(machine, IMAGE_FILE_MACHINE_I386);
+
+        // --- Walk section table to find .text ---
+        let sec_start = 20;
+        let mut text_raw_ptr = 0usize;
+        let mut text_raw_size = 0usize;
+        let mut text_reloc_ptr = 0usize;
+        let mut text_nreloc = 0usize;
+        for i in 0..nsections {
+            let off = sec_start + i * 40;
+            let name = &coff[off..off + 8];
+            let trimmed_end = name.iter().position(|&b| b == 0).unwrap_or(8);
+            if &name[..trimmed_end] == b".text" {
+                text_raw_size =
+                    u32::from_le_bytes(coff[off + 16..off + 20].try_into().unwrap()) as usize;
+                text_raw_ptr =
+                    u32::from_le_bytes(coff[off + 20..off + 24].try_into().unwrap()) as usize;
+                text_reloc_ptr =
+                    u32::from_le_bytes(coff[off + 24..off + 28].try_into().unwrap()) as usize;
+                text_nreloc =
+                    u16::from_le_bytes(coff[off + 32..off + 34].try_into().unwrap()) as usize;
+                break;
+            }
+        }
+        assert_ne!(text_raw_ptr, 0, ".text section not found");
+
+        // --- Verify .text contents are the i386 jump stub ---
+        let text = &coff[text_raw_ptr..text_raw_ptr + text_raw_size];
+        assert_eq!(
+            text,
+            &JMP_IX86_BYTES[..],
+            ".text should contain `ff 25 00 00 00 00 90 90`"
+        );
+        // The disp32 field at offset 2 is the implicit addend; must be 0.
+        let implicit_addend = u32::from_le_bytes(text[2..6].try_into().unwrap());
+        assert_eq!(implicit_addend, 0, "disp32 (implicit addend) must be 0");
+
+        // --- Verify the .text relocation: offset 2, IMAGE_REL_I386_DIR32 ---
+        assert_eq!(text_nreloc, 1, ".text should have exactly one relocation");
+        let rel = &coff[text_reloc_ptr..text_reloc_ptr + 10];
+        let rel_va = u32::from_le_bytes(rel[0..4].try_into().unwrap());
+        let sym_idx = u32::from_le_bytes(rel[4..8].try_into().unwrap()) as usize;
+        let rel_type = u16::from_le_bytes(rel[8..10].try_into().unwrap());
+        assert_eq!(rel_va, 2, "relocation must patch disp32 at offset 2");
+        assert_eq!(
+            rel_type, IMAGE_REL_I386_DIR32,
+            "i386 thunk must use absolute DIR32 (got 0x{:x}); REL32 here would silently \
+             produce thunks that fault on the first call",
+            rel_type
+        );
+
+        // --- Verify the relocation targets `__imp__bar` ---
+        // Each COFF symbol record is 18 bytes. Name: either inline 8 bytes
+        // or {0,0,0,0, offset_into_string_table_u32}.
+        let sym_off = sym_table_ptr + sym_idx * 18;
+        let name_field = &coff[sym_off..sym_off + 8];
+        let target_name: Vec<u8> = if name_field[0..4] == [0, 0, 0, 0] {
+            let str_off = u32::from_le_bytes(name_field[4..8].try_into().unwrap()) as usize;
+            let str_table_off = sym_table_ptr + nsymbols * 18;
+            let s = &coff[str_table_off + str_off..];
+            s[..s.iter().position(|&b| b == 0).unwrap()].to_vec()
+        } else {
+            let end = name_field.iter().position(|&b| b == 0).unwrap_or(8);
+            name_field[..end].to_vec()
+        };
+        assert_eq!(
+            target_name,
+            b"__imp__bar",
+            "i386 thunk reloc target must be `__imp__<mangled-name>`; got {:?}",
+            std::str::from_utf8(&target_name)
+        );
+    }
+
     #[ignore]
     #[test]
     fn debug_head_tail_export() {

--- a/src/gnu.rs
+++ b/src/gnu.rs
@@ -10,7 +10,11 @@ use crate::def::{ModuleDef, ShortExport};
 use crate::{ar, ArchiveMember, MachineType};
 
 const JMP_IX86_BYTES: [u8; 8] = [0xff, 0x25, 0x00, 0x00, 0x00, 0x00, 0x90, 0x90];
-const I386_RELOCATIONS: [(u64, i64, u16); 1] = [(2, -4, IMAGE_REL_I386_REL32)];
+// On i386, `ff 25 disp32` is `jmp dword ptr [disp32]` — an absolute
+// indirect jump (no rip-relative addressing). The disp32 must hold the
+// absolute VA of the IAT entry, so we use IMAGE_REL_I386_DIR32 (matches
+// binutils dlltool's BFD_RELOC_32 for the i386 jtab).
+const I386_RELOCATIONS: [(u64, i64, u16); 1] = [(2, 0, IMAGE_REL_I386_DIR32)];
 const AMD64_RELOCATIONS: [(u64, i64, u16); 1] = [(2, -4, IMAGE_REL_AMD64_REL32)];
 
 const JMP_ARM_BYTES: [u8; 12] = [
@@ -273,7 +277,7 @@ impl<'a> ObjectFactory<'a> {
                 | IMAGE_SCN_MEM_WRITE,
         };
         let id7 = obj.add_section(Vec::new(), b".idata$7".to_vec(), SectionKind::Data);
-        obj.section_mut(id4).flags = SectionFlags::Coff {
+        obj.section_mut(id7).flags = SectionFlags::Coff {
             characteristics: IMAGE_SCN_ALIGN_4BYTES
                 | IMAGE_SCN_CNT_INITIALIZED_DATA
                 | IMAGE_SCN_MEM_READ
@@ -350,19 +354,31 @@ impl<'a> ObjectFactory<'a> {
 
         let id7 = obj.add_section(Vec::new(), b".idata$7".to_vec(), SectionKind::Data);
         obj.section_mut(id7).flags = SectionFlags::Coff {
-            characteristics: IMAGE_SCN_ALIGN_4BYTES | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE,
+            characteristics: IMAGE_SCN_ALIGN_4BYTES
+                | IMAGE_SCN_CNT_INITIALIZED_DATA
+                | IMAGE_SCN_MEM_READ
+                | IMAGE_SCN_MEM_WRITE,
         };
         let id5 = obj.add_section(Vec::new(), b".idata$5".to_vec(), SectionKind::Data);
         obj.section_mut(id5).flags = SectionFlags::Coff {
-            characteristics: IMAGE_SCN_ALIGN_4BYTES | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE,
+            characteristics: IMAGE_SCN_ALIGN_4BYTES
+                | IMAGE_SCN_CNT_INITIALIZED_DATA
+                | IMAGE_SCN_MEM_READ
+                | IMAGE_SCN_MEM_WRITE,
         };
         let id4 = obj.add_section(Vec::new(), b".idata$4".to_vec(), SectionKind::Data);
         obj.section_mut(id4).flags = SectionFlags::Coff {
-            characteristics: IMAGE_SCN_ALIGN_4BYTES | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE,
+            characteristics: IMAGE_SCN_ALIGN_4BYTES
+                | IMAGE_SCN_CNT_INITIALIZED_DATA
+                | IMAGE_SCN_MEM_READ
+                | IMAGE_SCN_MEM_WRITE,
         };
         let id6 = obj.add_section(Vec::new(), b".idata$6".to_vec(), SectionKind::Data);
         obj.section_mut(id6).flags = SectionFlags::Coff {
-            characteristics: IMAGE_SCN_ALIGN_2BYTES | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE,
+            characteristics: IMAGE_SCN_ALIGN_2BYTES
+                | IMAGE_SCN_CNT_INITIALIZED_DATA
+                | IMAGE_SCN_MEM_READ
+                | IMAGE_SCN_MEM_WRITE,
         };
 
         let import_name = self.import_name.replace('.', "_");


### PR DESCRIPTION
- The i386 jump stub `ff 25 disp32` is an absolute indirect jump (`jmp dword ptr [disp32]`); i386 has no rip-relative addressing. Switch the relocation from IMAGE_REL_I386_REL32 (addend -4) to IMAGE_REL_I386_DIR32 (addend 0) to match binutils dlltool's BFD_RELOC_32 for the i386 jtab. The previous reloc would have caused first-call faults in linked binaries.

- Fix copy-paste in make_tail: characteristics intended for .idata$7 were being assigned to .idata$4 again.

- Add IMAGE_SCN_CNT_INITIALIZED_DATA to per-export .idata$4/$5/$6/$7 for consistency with make_head and binutils' SEC_HAS_CONTENTS.

Verified by linking against the regenerated .dll.a with both lld (mingw mode) and binutils ld from mingw-w64; resulting PE imports and thunks match dlltool reference output.